### PR TITLE
Add content grouping for Google Analytics.

### DIFF
--- a/source/layouts/layout.erb
+++ b/source/layouts/layout.erb
@@ -53,7 +53,9 @@ under the License.
       function gtag(){dataLayer.push(arguments);}
       gtag('js', new Date());
 
-      gtag('config', 'G-8KCYZ2CYMS');
+      gtag('config', 'G-8KCYZ2CYMS', {
+        'content_group' : 'WooCommerce Bookings API Docs',
+      });
     </script>
   </head>
 


### PR DESCRIPTION
This is a follow-up to #5 that adds a bit of additional configuration to our Google Analytics tracking tag so that we can segment traffic on GitHub Pages traffic more easily.