### PR TITLE
Replace crazy-max/ghaction-github-pages with official GitHub Pages actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,21 +3,35 @@ on:
   push:
     branches:
       - trunk
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: false
+
 jobs:
   build-and-deploy:
     if: github.repository_owner == 'woocommerce'
     name: Build and deploy
     runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Build
       run: ./build.sh
-    - name: Deploy to GitHub Pages
-      if: success()
-      uses: crazy-max/ghaction-github-pages@59173cb633d9a3514f5f4552a6a3e62c6710355c # v2
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    - name: Setup Pages
+      uses: actions/configure-pages@v5
+    - name: Upload artifact
+      uses: actions/upload-pages-artifact@v3
       with:
-        target_branch: gh-pages
-        build_dir: build
+        path: build
+    - name: Deploy to GitHub Pages
+      id: deployment
+      uses: actions/deploy-pages@v4


### PR DESCRIPTION
## Summary
- Replaces third-party `crazy-max/ghaction-github-pages` with the official `actions/deploy-pages` workflow (`actions/configure-pages`, `actions/upload-pages-artifact`, `actions/deploy-pages`)
- Bumps `actions/checkout` from v2 to v4
- Adds required `permissions` (`pages: write`, `id-token: write`) and `concurrency` settings
- Matches the pattern already used in [woocommerce-rest-api-docs](https://github.com/woocommerce/woocommerce-rest-api-docs)

## Note
The GitHub Pages source for this repo needs to be set to **GitHub Actions** (Settings → Pages → Source) instead of the `gh-pages` branch for this to work.

## Test plan
- [ ] Verify the Pages source is set to "GitHub Actions" in repo settings
- [ ] Merge and confirm the site deploys successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)